### PR TITLE
Trying to fix - https://github.com/vert-x/mod-rxvertx/issues/39

### DIFF
--- a/src/main/java/io/vertx/rxcore/java/http/RxHttpClient.java
+++ b/src/main/java/io/vertx/rxcore/java/http/RxHttpClient.java
@@ -109,6 +109,13 @@ public class RxHttpClient {
     };
     
     HttpClientRequest req=core.request(method,uri,rh);
+      // if connection negotion fails - exception handler on http-client. SSL Exception aren't caught on httpRequest, but on httpClient.
+      this.core.exceptionHandler(new Handler<Throwable>() {
+        @Override
+        public void handle(Throwable event) {
+          rh.fail(event);
+        }
+      });
       // if req fails, notify observers
       req.exceptionHandler(new Handler<Throwable>() {
           @Override


### PR DESCRIPTION
Hey Guys,

I am connecting to a server with self-signed cert on SSL, which causes SSL Handshake Exception.

In a vertx world, javax.net.ssl.SSLHandshakeException are handled by the exception handler attached to "HttpClient", not by the exception handler that's attached to "HttpClientRequest". I am proposing following change in RxHttpClient to handle it.

this.core.exceptionHandler(new Handler() {
@Override
public void handle(Throwable event) {
rh.fail(event);
}
});