### PR TITLE
Upgrade dependencies and fail method in RxMessage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,8 +52,8 @@ dependencies {
   provided "com.foo:foo-lib:1.0.1" - if you DON'T want it to be packaged in the module zip
   */
 
-  compile "com.netflix.rxjava:rxjava-core:$rxjavaVersion"
-  compile("com.netflix.rxjava:rxjava-groovy:$rxjavaVersion") {
+  compile "io.reactivex:rxjava:$rxjavaVersion"
+  compile("io.reactivex:rxgroovy:$rxgroovyVersion") {
     exclude group:"org.codehaus.groovy", module:"groovy-all"
   }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,16 +14,19 @@ testtimeout=300
 pullInDeps=false
 
 # RxJava version
-rxjavaVersion=0.20.7
+rxjavaVersion=1.1.0
+
+# RxGroovy version
+rxgroovyVersion=1.0.3
 
 # Gradle version
-gradleVersion=1.10
+gradleVersion=2.1
 
 # The version of Groovy language to compile against (if you are using Groovy compiled verticles or VertxTests)
-groovyLangModVersion=2.1.0-final
+groovyLangModVersion=2.1.1-final
 
 # The version of Groovy to use (if you are using Groovy)
-groovyVersion=2.3.3
+groovyVersion=2.4.5
 
 # The version of Vert.x
 vertxVersion=2.1.5
@@ -32,5 +35,5 @@ vertxVersion=2.1.5
 toolsVersion=2.0.3-final
 
 # The version of JUnit
-junitVersion=4.10
+junitVersion=4.11
 

--- a/gradle/vertx.gradle
+++ b/gradle/vertx.gradle
@@ -216,10 +216,10 @@ def loadProperties(String sourceFileName) {
 plugins.withType(IdeaPlugin) {
   idea {
     module {
-      scopes.PROVIDED.plus += configurations.provided
-      scopes.COMPILE.minus += configurations.provided
-      scopes.TEST.minus += configurations.provided
-      scopes.RUNTIME.minus += configurations.provided
+      scopes.PROVIDED.plus += [configurations.provided]
+      scopes.COMPILE.minus += [configurations.provided]
+      scopes.TEST.minus += [configurations.provided]
+      scopes.RUNTIME.minus += [configurations.provided]
     }
   }
 }

--- a/src/main/java/io/vertx/rxcore/java/eventbus/RxMessage.java
+++ b/src/main/java/io/vertx/rxcore/java/eventbus/RxMessage.java
@@ -72,4 +72,9 @@ public abstract class RxMessage<T> {
 
   /** Observe a reply with timeout */
   public abstract <R,T> Observable<RxMessage<T>> observeReplyWithTimeout(final R msg, final long timeout);
+
+  /** Send a signal that processing of this message failed */
+  public void fail(int failureCode, String message) {
+    coreMessage.fail(failureCode, message);
+  }
 }

--- a/src/test/java/io/vertx/rxcore/test/integration/java/EventBusIntegrationTest.java
+++ b/src/test/java/io/vertx/rxcore/test/integration/java/EventBusIntegrationTest.java
@@ -479,4 +479,17 @@ public class EventBusIntegrationTest extends TestVerticle {
 
     assertCountThenComplete(regulator.stream(res,out),401);
   }
+
+  @Test
+  public void testFail() {
+    final RxEventBus rxEventBus=new RxEventBus(vertx.eventBus());
+
+    rxEventBus.<String>registerHandler("fail").subscribe(new Action1<RxMessage<String>>() {
+      public void call(RxMessage<String> req) {
+        req.fail(-1, "oops");
+      }
+    });
+
+    assertErrorThenComplete(rxEventBus.observeSend("fail", "ping"), ReplyException.class, "oops");
+  }
 }


### PR DESCRIPTION
I've upgraded dependencies to this project (rxJava, rxGroovy, etc) to the current version and included the fail reply method in RxMessage.
